### PR TITLE
Add aligned alloc to WASM shim

### DIFF
--- a/gvox-sys/src/wasm_shim.rs
+++ b/gvox-sys/src/wasm_shim.rs
@@ -118,3 +118,11 @@ pub unsafe extern "C" fn memchr(str: *const c_void, ch: c_int, count: usize) -> 
         index += 1;
     }
 }
+
+#[no_mangle]
+pub unsafe extern "C" fn aligned_alloc(alignment: usize, size: usize) -> *mut c_void {
+    unsafe {
+        let layout = Layout::from_size_align_unchecked(size, alignment);
+        alloc(layout).cast()
+    }
+}


### PR DESCRIPTION
In the latest update of the WASI SDK (version 20.0), the `aligned_alloc` function appears to be included in one of the headers that `gvox-rs` uses. I had to patch it to get WASM compiling again.