### PR TITLE
Fix linking of mac builds

### DIFF
--- a/gvox-sys/build.rs
+++ b/gvox-sys/build.rs
@@ -20,6 +20,10 @@ fn main() {
         println!("cargo:rustc-link-lib=dylib=c++");
         println!("cargo:rustc-link-lib=dylib=c++abi");
         println!(
+            "cargo:rustc-link-search=native={}/build",
+            dst.display()
+        );
+        println!(
             "cargo:rustc-link-search=native={}/build/{}",
             dst.display(),
             get_profile()
@@ -38,6 +42,14 @@ fn main() {
                 if static_crt { 1 } else { 0 }
             ))
             .build();
+        
+        if std::env::var("CARGO_CFG_TARGET_OS") == Ok("macos".to_string()) {
+            println!("cargo:rustc-link-lib=dylib=c++");
+        }
+        println!(
+            "cargo:rustc-link-search=native={}/build",
+            dst.display()
+        );
         println!(
             "cargo:rustc-link-search=native={}/build/{}",
             dst.display(),


### PR DESCRIPTION
On `x86_64-apple-darwin`, builds were broken because:

- The CMake build outputs a file under the `build` directory rather than the `build/Debug` or `build/Release` directories
- The C++ standard library wasn't linking

This PR fixes these issues.